### PR TITLE
修正个人主页的正则匹配bug

### DIFF
--- a/src/locale/lang/zh_CN/github/page-profile.js
+++ b/src/locale/lang/zh_CN/github/page-profile.js
@@ -115,7 +115,7 @@ export default {
   regexp: [ // 正则翻译 (注意优先顺序)
     [/([\d,]+) contributions in the last year/, '$1 次贡献在过去的一年中'],
     [/Created (\d+)[\s\r\n]+commits? in[\s\r\n]+(\d+)[\s\r\n]+repositor(y|ies)/, '在 $2 个库中创建了 $1 次提交'],
-    [/Opened (\d+)[\s\r\n]+issues?[\s\r\n]+in (\d+)[\s\r\n]+ repositor(y|ies)/, '在 $2 个库中打开了 $1 个问题'],
+    [/Opened (\d+)[\s\r\n]+issues?[\s\r\n]+in (\d+)[\s\r\n]+repositor(y|ies)/, '在 $2 个库中打开了 $1 个问题'],
     [/Created (\d+)[\s\r\n]+repositor(y|ies)/, '创建了 $1 个仓库'],
     [/Opened (\d+)[\s\r\n]+other[\s\r\n]+pull requests?/, '发起了 $1 个拉取请求'],
     [/Opened (\d+)[\s\r\n]+other[\s\r\n]+issues?/, '开了 $1 个其他问题'],

--- a/src/locale/lang/zh_CN/github/page-profile.js
+++ b/src/locale/lang/zh_CN/github/page-profile.js
@@ -114,8 +114,8 @@ export default {
   },
   regexp: [ // 正则翻译 (注意优先顺序)
     [/([\d,]+) contributions in the last year/, '$1 次贡献在过去的一年中'],
-    [/Created (\d+)[\s\r\n]+commits? in[\s\r\n]+(\d+)[\s\r\n]+repositor(y|ies)/, '在 $1 个库中创建了 $2 次提交'],
-    [/Opened (\d+)[\s\r\n]+issues?[\s\r\n]+in (\d+) repositor(y|ies)/, '在 $1 个库中打开了 $2 个问题'],
+    [/Created (\d+)[\s\r\n]+commits? in[\s\r\n]+(\d+)[\s\r\n]+repositor(y|ies)/, '在 $2 个库中创建了 $1 次提交'],
+    [/Opened (\d+)[\s\r\n]+issues?[\s\r\n]+in (\d+)[\s\r\n]+ repositor(y|ies)/, '在 $2 个库中打开了 $1 个问题'],
     [/Created (\d+)[\s\r\n]+repositor(y|ies)/, '创建了 $1 个仓库'],
     [/Opened (\d+)[\s\r\n]+other[\s\r\n]+pull requests?/, '发起了 $1 个拉取请求'],
     [/Opened (\d+)[\s\r\n]+other[\s\r\n]+issues?/, '开了 $1 个其他问题'],


### PR DESCRIPTION
具体修正内容：
1.正则匹配commits时，子匹配顺序错误，库数与commits数反了，如下图：
![qq 20171111021038](https://user-images.githubusercontent.com/15937065/32672335-98f68a74-c685-11e7-8729-895fa5540f52.png)
2.正则匹配统计issues时，匹配不到，如下：
![qq 20171111021200](https://user-images.githubusercontent.com/15937065/32672380-c73a02c6-c685-11e7-88e0-b33d35012c79.png)

